### PR TITLE
change selected identifier for block chooserwidget

### DIFF
--- a/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
+++ b/app/code/Magento/Cms/Block/Adminhtml/Block/Widget/Chooser.php
@@ -100,7 +100,7 @@ class Chooser extends \Magento\Backend\Block\Widget\Grid\Extended
         $js = '
             function (grid, event) {
                 var trElement = Event.findElement(event, "tr");
-                var blockId = trElement.down("td").innerHTML.replace(/^\s+|\s+$/g,"");
+                var blockId = trElement.down("td").next().next().innerHTML.replace(/^\s+|\s+$/g,"");
                 var blockTitle = trElement.down("td").next().innerHTML;
                 ' .
             $chooserJsObject .


### PR DESCRIPTION

### Description (*)
magento can translate contents only when adding new blocks, assigned to different stores with the same identifier. when adding a cms block e.g. within a cms page a cms block widget can add the relation as {{widget .... }}. the id is chosen for the widget to load the block. this will break any translation possibility as one id can not contain multiple translations.

as the widget loads blocks by id or identifier without any further changes the identifier is now selected on selection.

### Manual testing scenarios (*)

1. go to a cms page
2. add a cms block widget
3. click show/hide editor
4. see if block identifier is chosen for the widgets attribute
5. go to cms page, see if block is correctly shown

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
